### PR TITLE
マイグレーションファイルの修正と外部キーファイルの追加

### DIFF
--- a/database/migrations/2021_05_31_141139_create_stores_table.php
+++ b/database/migrations/2021_05_31_141139_create_stores_table.php
@@ -16,10 +16,6 @@ class CreateStoresTable extends Migration
         Schema::create('stores', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->unsignedBigInteger('category_id');
-            $table->foreign('category_id')->references('id')->on('categories');
-            $table->unsignedBigInteger('prefecture_id');
-            $table->foreign('prefecture_id')->references('id')->on('prefectures');
             $table->string('address');
             $table->string('phone_number');
             $table->string('opening_hour');

--- a/database/migrations/2021_05_31_142445_create_reviews_table.php
+++ b/database/migrations/2021_05_31_142445_create_reviews_table.php
@@ -24,7 +24,7 @@ class CreateReviewsTable extends Migration
             $table->foreign('category_id')->references('id')->on('categories');
             $table->integer('review');
             $table->string('post_image');
-            $table->timestamps('published_at');
+            $table->dateTime('published_at');
             $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users');
             $table->timestamps();

--- a/database/migrations/2021_06_02_124353_add_foreign_key_to_stores.php
+++ b/database/migrations/2021_06_02_124353_add_foreign_key_to_stores.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeyToStores extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('stores', function (Blueprint $table) {
+        
+            $table->unsignedBigInteger('category_id')->after('name');
+            $table->foreign('category_id')->references('id')->on('categories');
+            $table->unsignedBigInteger('prefecture_id')->after('category_id');
+            $table->foreign('prefecture_id')->references('id')->on('prefectures');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('stores', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
### 【修正】Reviewsテーブルのマイグレーションファイル
published_atのカラム型をtimestampsからdateTimeへ修正

### 【修正】Storesテーブルのマイグレーションファイル
外部キーのCategories_idとprefecture_idのみが外部キーの制限でマイグレートできないようになっていたのでこの二つのカラムに関する記述を消去

### 【追加】Storesテーブルの外部キーを加えるファイル
Storesテーブルで作れていないCategories_idとprefecture_idのカラムを作るファイルを追加