### PR TITLE
口コミ作成ページのviewにCSSが効くようにする　下書き保存ボタンのところのif文を消去する

### DIFF
--- a/resources/views/Reviews/create.blade.php
+++ b/resources/views/Reviews/create.blade.php
@@ -1,7 +1,8 @@
 @extends('layouts.header')
 
 @section('css')
-<link rel="stylesheet" type="text/css" href="css/style.css">
+<link rel="stylesheet" href="{{ asset('css/reset.css') }}">
+<link rel="stylesheet" type="text/css" href="{{ asset('css/style.css') }}">
 @endsection
 
 @section('content')
@@ -204,9 +205,7 @@
                                 <button type="submit" class="btn post">口コミを投稿する</button>
                             </div>
                             <div class="text-right">
-                                @if{{$review->published_at < $review->created_at }}
                                 <button type="submit" name="draft" class="btn save-draft">下書きに保存</button>
-                                @endif
                             </div>
                         </div>{{-- action-button --}}
                     </div>{{-- buttons --}}


### PR DESCRIPTION
### create.blade.php
下書きボタンのif文のところを修正
新規作成であることを考えると必要ないものでした

CSSのリンクタグのところasset関数での記載に変更
issueではindexページだけで現在野呂さんも修正済んでる気もするのですが一応こっちも修正しています。
