### PR TITLE
indexページにCSSが効くように修正

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,7 +1,8 @@
 @extends('layouts.header')
 
 @section('css')
-<link rel="stylesheet" href="./css/style.css">
+<link rel="stylesheet" href="{{ asset('css/reset.css') }}">
+<link rel="stylesheet" type="text/css" href="{{ asset('css/style.css') }}">
 @endsection
 
 @section('content')


### PR DESCRIPTION
## index.blade.php
リンクタグのCSSのところをasset関数での記載に修正しました。
始めはCSSが効きますが、検索した後とかだと階層の関係で効かなくなってました。