### PR TITLE
create.blade.php’口コミを投稿するボタン’に投稿機能を追加　show.blade.php’鉛筆マーク’からcreateページへとぶ機能追加

### DIFF
--- a/resources/views/Reviews/create.blade.php
+++ b/resources/views/Reviews/create.blade.php
@@ -132,11 +132,12 @@
                 </ul>
             </div>
             @endif
-            <form action=" {{route('reviews.create')}} " method="post" enctype='multipart/form-data'>
+            <form action=" {{route('reviews.store')}} " method="post" enctype='multipart/form-data'>
                 @csrf
+                <input type="hidden" name="store_id" value="{{$store->id}}">
                 <div class="rate">
                     <p>評価(★)</p>
-                    <select name="rating">
+                    <select name="review">
                         <option value="0">☆☆☆☆☆</option>
                         <option value="1">★☆☆☆☆</option>
                         <option value="2">★★☆☆☆</option>
@@ -160,25 +161,25 @@
                 </div>
                 <div class="form-group">
                     <label class="space">カテゴリ</label>
-                    <select id="sweets">
-                        <option value="category_id">ケーキ
+                    <select id="sweets" name="category_id">
+                        <option value="1">ケーキ
                         </option>
-                        <option value="category_id">タルト、パイ
+                        <option value="2">タルト、パイ
                         </option>
-                        <option value="category_id">プリン
+                        <option value="3">プリン
                         </option>
-                        <option value="category_id">チョコレート
+                        <option value="4">チョコレート
                         </option>
-                        <option value="category_id">シュークリーム
+                        <option value="5">シュークリーム
                         </option>
-                        <option value="category_id">クッキー
+                        <option value="6">クッキー
                         </option>
-                        <option value="category_id">アイスクリーム、シャーベット</option>
-                        <option value="category_id">クレープ
+                        <option value="7">アイスクリーム、シャーベット</option>
+                        <option value="8">クレープ
                         </option>
-                        <option value="category_id">パフェ
+                        <option value="9">パフェ
                         </option>
-                        <option value="category_id">その他
+                        <option value="10">その他
                         </option>
                     </select>
                 </div>

--- a/resources/views/stores/show.blade.php
+++ b/resources/views/stores/show.blade.php
@@ -141,11 +141,12 @@
         <div class="review">
             <div class="posting">
                 <h3>口コミ一覧</h3>
-                <button type="submit" class="btn-text-danger">
-                    <img src="{{ asset('css/rogo_addreview.jpg') }}" alt="口コミ鉛筆" class="rogo">
-                </button>
+                {{-- <button type="submit" class="btn-text-danger"> --}}
+                    <a href="/reviews/create?id={{$store->id}}">
+                        <img src="{{ asset('css/rogo_addreview.jpg') }}" alt="口コミ鉛筆" class="rogo">
+                    </a>
+                {{-- </button> --}}
                 <div class="word font">
-                    <a href="/reviews/create?store_id={{$store->id}}"></a>
                     <p>口コミを投稿する</p>
                 </div>
             </div>


### PR DESCRIPTION
## create.blade.php
フォームのアクションのルートをstoreへ変更
評価とカテゴリにname属性を追加
カテゴリのvalue属性をカテゴリーIDとなるよう数字へ変更

## show.blade.php
口コミ鉛筆をクリックすることで投稿ができるようにaタグの位置を変更
口コミ鉛筆の下の楕円のボタンをコメントアウト

### memo
投稿処理でエラーがでるのでReviewControllerのcreateメソッド内57行目とかにデバックを入れて確認していました。